### PR TITLE
ci(release): remove npm token env variable, use trusted publishers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,5 +26,3 @@ jobs:
       - run: npm ci
       - run: npm test
       - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
Replace explicit NPM_TOKEN environment variable with OIDC-based trusted publishing for enhanced security and simplified token management.