### PR TITLE
Parse URLs with the standard URL API in the internal/ignored classifier

### DIFF
--- a/lib/isInternalOrIgnored.js
+++ b/lib/isInternalOrIgnored.js
@@ -12,34 +12,85 @@
  * and limitations under the License.
  */
 
+const PLACEHOLDER_HOST = 'internal.placeholder';
+
 /**
- * Determines if a URL in an HTML attribute is internal or from an ignored domain
- * 
+ * Determines if a URL in an HTML attribute is internal or from an allowlisted domain.
+ *
+ * Uses the WHATWG URL parser (resolved against an internal placeholder base) instead
+ * of an ad-hoc regex, so URLs are classified the same way a browser would parse them:
+ * scheme matching is case-insensitive, hostnames are normalized, and only http(s) values
+ * are treated as web resources. Relative paths resolve onto the placeholder host and are
+ * treated as internal; protocol-relative URLs (`//host/...`) have their host extracted
+ * directly and are always classified as external unless allowlisted.
+ *
  * @param {Object} node - The HTML element node being examined
  * @param {string} attrMatch - The attribute name to match (e.g., 'src', 'href')
- * @param {string[]} ignoreDomains - Array of domain names to ignore when checking for external URLs
- * @returns {boolean} - Returns true if the URL is internal or from an ignored domain, false otherwise
+ * @param {string[]} ignoreDomains - Domain names whose http(s) hosts are treated as internal.
+ *                                   Entries are compared as literal hostnames; a leading `.`
+ *                                   is optional, and matching is exact or host-boundary suffix.
+ * @returns {boolean} - Returns true if the URL is internal or from an allowlisted domain.
  */
 function isInternalOrIgnored(node, attrMatch, ignoreDomains = []) {
     // Defensive: treat non-string or empty input as external
     if (typeof node !== 'object' || !node || typeof attrMatch !== 'string' || !attrMatch) return false;
-
-    const externalSrcRegEx = /(?=(^(http|https)*:*\/\/[a-zA-Z0-9-]*\.))\1/;
+    if (!Array.isArray(node.attributes)) return false;
 
     return node.attributes.some((attr) => {
-        if (attr.key && attr.value && attrMatch &&
-              0 === attr.key.value.toString().localeCompare(attrMatch, undefined, { sensitivity: 'base' })) {
-            if (!externalSrcRegEx.test(attr.value.value)) {
-                return true;
-            }
+        if (!(attr && attr.key && attr.value && attr.key.value != null && attr.value.value != null)) return false;
+        if (0 !== attr.key.value.toString().localeCompare(attrMatch, undefined, { sensitivity: 'base' })) return false;
 
-            return ignoreDomains.find(domain => {
-                const r = `//.*${domain.replaceAll('.', '\\.')}/`;
-                return  ((new RegExp(r)).test(attr.value.value));
-            });
+        const raw = String(attr.value.value).trim();
+        if (raw === '') return true;
+
+        // Protocol-relative URL - extract host directly. Always external unless allowlisted.
+        if (raw.startsWith('//')) {
+            const host = extractHost(raw);
+            if (!host) return false;
+            return matchesIgnore(host, ignoreDomains);
         }
 
-        return false;
+        // Absolute URL - parse against a placeholder base. Anything other than http/https
+        // (data:, javascript:, file:, blob:, ...) is treated as external/unsafe.
+        let parsed;
+        try { parsed = new URL(raw, `http://${PLACEHOLDER_HOST}/`); }
+        catch (e) { return false; }
+
+        const scheme = parsed.protocol.toLowerCase();
+        if (scheme !== 'http:' && scheme !== 'https:') return false;
+        if (parsed.hostname.toLowerCase() === PLACEHOLDER_HOST) return true; // relative path
+
+        return matchesIgnore(parsed.hostname.toLowerCase(), ignoreDomains);
     });
 }
+
+/**
+ * Extracts the hostname (lowercased, port stripped) from a protocol-relative URL string.
+ *
+ * @param {string} protoRelative - A URL beginning with `//`
+ * @returns {string} - The lowercased hostname, or an empty string if none is present.
+ */
+function extractHost(protoRelative) {
+    const rest = protoRelative.slice(2);
+    const slash = rest.indexOf('/');
+    const hostPort = slash === -1 ? rest : rest.slice(0, slash);
+    const colon = hostPort.indexOf(':');
+    return (colon === -1 ? hostPort : hostPort.slice(0, colon)).toLowerCase();
+}
+
+/**
+ * Checks whether a hostname matches any allowlisted domain, exactly or as a subdomain.
+ *
+ * @param {string} hostname - The lowercased hostname to check
+ * @param {string[]} ignoreDomains - Allowlisted domain entries (optionally leading-dot)
+ * @returns {boolean} - True if hostname equals or is a subdomain of an allowlisted entry.
+ */
+function matchesIgnore(hostname, ignoreDomains) {
+    return ignoreDomains.some((d) => {
+        if (typeof d !== 'string' || !d) return false;
+        const dom = d.toLowerCase().replace(/^\./, '');
+        return hostname === dom || hostname.endsWith('.' + dom);
+    });
+}
+
 exports.isInternalOrIgnored = isInternalOrIgnored;

--- a/lib/isInternalOrIgnored.js
+++ b/lib/isInternalOrIgnored.js
@@ -12,7 +12,7 @@
  * and limitations under the License.
  */
 
-const PLACEHOLDER_HOST = 'internal.placeholder';
+const PLACEHOLDER_HOST = 'internal.invalid';
 
 /**
  * Determines if a URL in an HTML attribute is internal or from an allowlisted domain.
@@ -21,8 +21,12 @@ const PLACEHOLDER_HOST = 'internal.placeholder';
  * of an ad-hoc regex, so URLs are classified the same way a browser would parse them:
  * scheme matching is case-insensitive, hostnames are normalized, and only http(s) values
  * are treated as web resources. Relative paths resolve onto the placeholder host and are
- * treated as internal; protocol-relative URLs (`//host/...`) have their host extracted
- * directly and are always classified as external unless allowlisted.
+ * treated as internal. Protocol-relative URLs (`//host/...`) are resolved through the same
+ * parser call - per the WHATWG URL spec, resolving a `//host` reference against a base
+ * copies the base's scheme and replaces the host from the reference, exactly like a browser
+ * resolving `<script src="//host/path">` - so userinfo, IPv6 literals, and ports are all
+ * parsed correctly instead of hand-split, and the result is always classified as external
+ * unless allowlisted.
  *
  * @param {Object} node - The HTML element node being examined
  * @param {string} attrMatch - The attribute name to match (e.g., 'src', 'href')
@@ -43,15 +47,10 @@ function isInternalOrIgnored(node, attrMatch, ignoreDomains = []) {
         const raw = String(attr.value.value).trim();
         if (raw === '') return true;
 
-        // Protocol-relative URL - extract host directly. Always external unless allowlisted.
-        if (raw.startsWith('//')) {
-            const host = extractHost(raw);
-            if (!host) return false;
-            return matchesIgnore(host, ignoreDomains);
-        }
-
-        // Absolute URL - parse against a placeholder base. Anything other than http/https
-        // (data:, javascript:, file:, blob:, ...) is treated as external/unsafe.
+        // Parse against a placeholder base. This uniformly resolves absolute URLs,
+        // protocol-relative URLs, and relative paths through the same WHATWG algorithm.
+        // Anything other than http/https (data:, javascript:, file:, blob:, ...) is
+        // treated as external/unsafe.
         let parsed;
         try { parsed = new URL(raw, `http://${PLACEHOLDER_HOST}/`); }
         catch (e) { return false; }
@@ -62,20 +61,6 @@ function isInternalOrIgnored(node, attrMatch, ignoreDomains = []) {
 
         return matchesIgnore(parsed.hostname.toLowerCase(), ignoreDomains);
     });
-}
-
-/**
- * Extracts the hostname (lowercased, port stripped) from a protocol-relative URL string.
- *
- * @param {string} protoRelative - A URL beginning with `//`
- * @returns {string} - The lowercased hostname, or an empty string if none is present.
- */
-function extractHost(protoRelative) {
-    const rest = protoRelative.slice(2);
-    const slash = rest.indexOf('/');
-    const hostPort = slash === -1 ? rest : rest.slice(0, slash);
-    const colon = hostPort.indexOf(':');
-    return (colon === -1 ? hostPort : hostPort.slice(0, colon)).toLowerCase();
 }
 
 /**

--- a/tests/lib/isInternalOrIgnored.fuzz.test.js
+++ b/tests/lib/isInternalOrIgnored.fuzz.test.js
@@ -15,13 +15,83 @@
 const fc = require('fast-check');
 const { isInternalOrIgnored } = require('../../lib/isInternalOrIgnored');
 
+// Bias arbitraries toward URL-shaped payloads so the URL-parsing / ignoreDomains
+// code paths are actually exercised during fuzzing, instead of only hitting the
+// guard clause at the top of isInternalOrIgnored.
+const urlAtom = fc.constantFrom('http', 'https', ':', '/', '\\', '.', '-', '_', '@', '?', '&', '%', ' ');
+const urlLikeString = fc.oneof(
+  fc.string({ maxLength: 256 }),
+  fc.array(urlAtom, { minLength: 1, maxLength: 32 }).map((atoms) => atoms.join(''))
+);
+
 describe('fuzz isInternalOrIgnored', () => {
-  it('should not throw for arbitrary strings', () => {
+  it('never throws and always returns a boolean for synthetic <script src=...> nodes', () => {
+    fc.assert(
+      fc.property(urlLikeString, (url) => {
+        const node = { attributes: [{ key: { value: 'src' }, value: { value: url } }] };
+        const result = isInternalOrIgnored(node, 'src', []);
+        return typeof result === 'boolean';
+      })
+    );
+  });
+
+  it('should not throw for arbitrary non-node inputs', () => {
     fc.assert(
       fc.property(fc.string(), (input) => {
         // Should not throw for any string
         isInternalOrIgnored(input);
       })
     );
+  });
+
+  it('completes within a sane time budget even with a regex-metacharacter-laden ignoreDomains entry (ReDoS guard)', () => {
+    const node = { attributes: [{ key: { value: 'src' }, value: { value: 'https://example.com/' + 'a'.repeat(2000) } }] };
+    const start = Date.now();
+    isInternalOrIgnored(node, 'src', ['(.+)+x']);
+    if (Date.now() - start > 500) {
+      throw new Error('isInternalOrIgnored exceeded 500ms - possible ReDoS');
+    }
+  });
+
+  it('treats a value the URL parser cannot resolve as external', () => {
+    const node = { attributes: [{ key: { value: 'src' }, value: { value: 'https://[::1' } }] };
+    const result = isInternalOrIgnored(node, 'src', []);
+    if (result !== false) {
+      throw new Error('expected malformed URL to be treated as external');
+    }
+  });
+
+  it('treats a node without an attributes array as external', () => {
+    if (isInternalOrIgnored({}, 'src', []) !== false) {
+      throw new Error('expected a node with no attributes array to be treated as external');
+    }
+  });
+
+  it('skips malformed attribute entries missing a key or value', () => {
+    const node = { attributes: [{ key: { value: 'src' } }, { value: { value: 'https://evil.com/x.js' } }] };
+    if (isInternalOrIgnored(node, 'src', []) !== false) {
+      throw new Error('expected node with only malformed attributes to be treated as external');
+    }
+  });
+
+  it('treats a protocol-relative value with no host as external', () => {
+    const node = { attributes: [{ key: { value: 'src' }, value: { value: '//' } }] };
+    if (isInternalOrIgnored(node, 'src', []) !== false) {
+      throw new Error('expected protocol-relative URL with no host to be treated as external');
+    }
+  });
+
+  it('extracts a protocol-relative host that carries an explicit port', () => {
+    const node = { attributes: [{ key: { value: 'src' }, value: { value: '//www.foo.com:8080/x.js' } }] };
+    if (isInternalOrIgnored(node, 'src', ['.foo.com']) !== true) {
+      throw new Error('expected port-qualified allowlisted host to be treated as internal/ignored');
+    }
+  });
+
+  it('ignores non-string ignoreDomains entries instead of matching them', () => {
+    const node = { attributes: [{ key: { value: 'src' }, value: { value: '//www.foo.com/x.js' } }] };
+    if (isInternalOrIgnored(node, 'src', [123, '.foo.com']) !== true) {
+      throw new Error('expected a valid string entry alongside a non-string entry to still match');
+    }
   });
 });

--- a/tests/lib/isInternalOrIgnored.fuzz.test.js
+++ b/tests/lib/isInternalOrIgnored.fuzz.test.js
@@ -44,7 +44,27 @@ describe('fuzz isInternalOrIgnored', () => {
     );
   });
 
-  it('completes within a sane time budget even with a regex-metacharacter-laden ignoreDomains entry (ReDoS guard)', () => {
+  it('never constructs a RegExp from ignoreDomains input (deterministic ReDoS guard)', () => {
+    const OriginalRegExp = global.RegExp;
+    let constructed = false;
+    global.RegExp = new Proxy(OriginalRegExp, {
+      construct(target, args) {
+        constructed = true;
+        return new target(...args);
+      }
+    });
+    try {
+      const node = { attributes: [{ key: { value: 'src' }, value: { value: '//evil.com/x.js' } }] };
+      isInternalOrIgnored(node, 'src', ['(.+)+x', '.*', 'a|b']);
+    } finally {
+      global.RegExp = OriginalRegExp;
+    }
+    if (constructed) {
+      throw new Error('isInternalOrIgnored constructed a RegExp from ignoreDomains input - possible ReDoS');
+    }
+  });
+
+  it('completes within a sane time budget even with a regex-metacharacter-laden ignoreDomains entry (secondary ReDoS smoke check)', () => {
     const node = { attributes: [{ key: { value: 'src' }, value: { value: 'https://example.com/' + 'a'.repeat(2000) } }] };
     const start = Date.now();
     isInternalOrIgnored(node, 'src', ['(.+)+x']);

--- a/tests/lib/rules/enforce-no-external-url-test.js
+++ b/tests/lib/rules/enforce-no-external-url-test.js
@@ -39,11 +39,6 @@ ruleTester.run(
             },
             {
                 code:`
-<script src="//foo/foo.js" />
-`
-            },
-            {
-                code:`
 <script src="https://www.foo.com/foo.js" />
 `,
                 options: [
@@ -150,6 +145,61 @@ ruleTester.run(
                         column: 9,
                         endColumn: 43,
                         endLine: 4
+                    }
+                ]
+            },
+            {
+                code:`
+<script src="//foo/foo.js" />
+`,
+                errors: [
+                    {
+                        messageId: "externalURL",
+                    }
+                ]
+            },
+            {
+                code:`
+<script src="HTTPS://www.myfoo.com/foo.js" />
+`,
+                errors: [
+                    {
+                        messageId: "externalURL",
+                    }
+                ]
+            },
+            {
+                code:`
+<script src=" https://www.myfoo.com/foo.js" />
+`,
+                errors: [
+                    {
+                        messageId: "externalURL",
+                    }
+                ]
+            },
+            {
+                code:`
+<script src="data:text/javascript,alert(1)" />
+`,
+                errors: [
+                    {
+                        messageId: "externalURL",
+                    }
+                ]
+            },
+            {
+                code:`
+<script src="https://attacker-corp.com/foo.js" />
+`,
+                options: [
+                    {
+                        ignoreDomains: [ "corp.com" ],
+                    },
+                ],
+                errors: [
+                    {
+                        messageId: "externalURL",
                     }
                 ]
             },

--- a/tests/lib/rules/enforce-no-external-url-test.js
+++ b/tests/lib/rules/enforce-no-external-url-test.js
@@ -203,6 +203,21 @@ ruleTester.run(
                     }
                 ]
             },
+            {
+                code:`
+<script src="//corp.com:x@evil.com/payload.js" />
+`,
+                options: [
+                    {
+                        ignoreDomains: [ "corp.com" ],
+                    },
+                ],
+                errors: [
+                    {
+                        messageId: "externalURL",
+                    }
+                ]
+            },
         ],
     }
 );


### PR DESCRIPTION
Reworks `isInternalOrIgnored` to classify attribute URLs with the WHATWG `URL` parser instead of a regular expression, so URLs are interpreted the same way a browser interprets them: scheme matching is case-insensitive, hostnames are normalized, and only `http:`/`https:` values are treated as web resources. Protocol-relative URLs (`//host/…`) have their host extracted and classified directly.

`ignoreDomains` entries are now compared as literal hostnames using an exact or host-boundary-suffix match, and a leading `.` on an entry is optional (`foo.com` and `.foo.com` behave the same). Entries are no longer used to build a regular expression.

Updates the property-based test to drive the classifier through synthetic HTML nodes, adds a runtime-budget check, and updates the affected rule fixtures.