### PR TITLE
Validate the integrity attribute against the Subresource Integrity grammar

### DIFF
--- a/docs/rules/require-script-integrity.md
+++ b/docs/rules/require-script-integrity.md
@@ -15,6 +15,11 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.0/jquery.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 ```
 
+The `integrity` value must match the [Subresource Integrity](https://www.w3.org/TR/SRI/#the-integrity-attribute)
+format: `sha256-`, `sha384-`, or `sha512-` followed by a base64-encoded digest (optionally as a
+whitespace-separated list of hashes). Values that don't match this format - including weaker
+algorithms like `sha1` - are treated the same as a missing `integrity` attribute.
+
 #### Options
 
 ##### `ignoredDomains`

--- a/docs/rules/require-script-integrity.md
+++ b/docs/rules/require-script-integrity.md
@@ -22,7 +22,7 @@ algorithms like `sha1` - are treated the same as a missing `integrity` attribute
 
 #### Options
 
-##### `ignoredDomains`
+##### `ignoreDomains`
 
 You can provide an array of allowed domains that are ignored.
 

--- a/lib/rules/require-script-integrity.js
+++ b/lib/rules/require-script-integrity.js
@@ -65,7 +65,7 @@ module.exports = {
             }
         ],
         messages: {
-            [MESSAGE_IDS.MISSING_INTEGRITY]: "Missing `integrity` attribute",
+            [MESSAGE_IDS.MISSING_INTEGRITY]: "Missing or invalid `integrity` attribute",
         }
     },
     /**

--- a/lib/rules/require-script-integrity.js
+++ b/lib/rules/require-script-integrity.js
@@ -15,6 +15,23 @@
 const { isInternalOrIgnored } = require("../isInternalOrIgnored");
 
 /**
+ * Subresource Integrity grammar - a single hash or whitespace-separated list of hashes,
+ * each `<algo>-<base64>` where algo is one of sha256/sha384/sha512. Anything else
+ * (including sha1, md5, junk strings, whitespace-only values, placeholders) is rejected.
+ *
+ * Spec: https://www.w3.org/TR/SRI/#the-integrity-attribute
+ * @type {RegExp}
+ */
+const SRI_RE = /^(sha(256|384|512)-[A-Za-z0-9+/]+={0,2})(\s+sha(256|384|512)-[A-Za-z0-9+/]+={0,2})*$/;
+
+/**
+ * The HTML attribute name that carries the SRI hash. HTML attribute names are
+ * case-insensitive, so comparisons against this constant are done in lowercase.
+ * @type {string}
+ */
+const INTEGRITY_KEY = "integrity";
+
+/**
  * Message IDs used for rule reporting
  * @type {Object}
  */
@@ -89,14 +106,16 @@ module.exports = {
 }
 
 /**
- * Checks if a node has a non-empty integrity attribute
+ * Checks if a node has an integrity attribute whose value matches the SRI grammar
  * @param {Object} node - The HTML element node to check
- * @returns {boolean} - Returns true if the node has a non-empty integrity attribute, false otherwise
+ * @returns {boolean} - Returns true if the node has a valid integrity attribute, false otherwise
  */
 function hasIntegrityAttrAndValue(node) {
     return node.attributes.some((attr) => {
-        if (attr.key && attr.value) {
-            return ((attr.key.value === "integrity" && typeof attr.value.value === "string" && attr.value.value !== ""));
-        }
+        if (!attr || !attr.key || !attr.value) return false;
+        const key = String(attr.key.value || "").toLowerCase();
+        if (key !== INTEGRITY_KEY) return false;
+        const value = String(attr.value.value || "").trim();
+        return SRI_RE.test(value);
     });
 }

--- a/tests/lib/rules/require-script-integrity-test.js
+++ b/tests/lib/rules/require-script-integrity-test.js
@@ -54,6 +54,16 @@ ruleTester.run(
             },
             {
                 code:`
+<script src="https://cdn.example.com/foo.js" integrity="sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU= sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC" />
+`
+            },
+            {
+                code:`
+<script src="https://cdn.example.com/foo.js" integrity=" sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC " />
+`
+            },
+            {
+                code:`
 <script src="https://www.foo.com/foo.js" />
 `,
                 options: [

--- a/tests/lib/rules/require-script-integrity-test.js
+++ b/tests/lib/rules/require-script-integrity-test.js
@@ -24,22 +24,32 @@ ruleTester.run(
         valid: [
             {
                 code:`
-<script src="foo.js" integrity="foobar" />
+<script src="foo.js" integrity="sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC" />
 `
             },
             {
                 code:`
 <script src="foo.js" />
 `
-            },            
+            },
             {
                 code:`
 <html>
     <head>
-        <script src="foo.js" integrity="foobar" />
+        <script src="foo.js" integrity="sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC" />
     </head>
     <body></body>
 </html>
+`
+            },
+            {
+                code:`
+<script src="https://cdn.example.com/foo.js" integrity="sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=" />
+`
+            },
+            {
+                code:`
+<script src="https://cdn.example.com/foo.js" INTEGRITY="sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC" />
 `
             },
             {
@@ -110,6 +120,46 @@ ruleTester.run(
                         column: 9,
                         endColumn: 43,
                         endLine: 4
+                    }
+                ]
+            },
+            {
+                code:`
+<script src="https://cdn.example.com/foo.js" integrity="foobar" />
+`,
+                errors: [
+                    {
+                        messageId: "missingIntegrity",
+                    }
+                ]
+            },
+            {
+                code:`
+<script src="https://cdn.example.com/foo.js" integrity="placeholder" />
+`,
+                errors: [
+                    {
+                        messageId: "missingIntegrity",
+                    }
+                ]
+            },
+            {
+                code:`
+<script src="https://cdn.example.com/foo.js" integrity="sha1-abc" />
+`,
+                errors: [
+                    {
+                        messageId: "missingIntegrity",
+                    }
+                ]
+            },
+            {
+                code:`
+<script src="https://cdn.example.com/foo.js" async integrity="" />
+`,
+                errors: [
+                    {
+                        messageId: "missingIntegrity",
                     }
                 ]
             },


### PR DESCRIPTION
`require-script-integrity` now confirms that the `integrity` value matches the W3C Subresource Integrity format — `sha256`, `sha384`, or `sha512` followed by a base64 digest, optionally as a whitespace-separated list of hashes — instead of accepting any non-empty string. The `integrity` attribute name is matched case-insensitively and surrounding whitespace is trimmed before validation.

Test fixtures are updated to use real SRI hashes and to cover values that do not meet the grammar, and the rule doc now documents the expected format.