### PR TITLE
Provide the recommended config as an ESLint flat config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - JSDocs documentation
 - Test coverage with nyc and coverage thresholds
 - Fuzzing
+- `configs.recommendedLegacy`, a `.eslintrc`-shaped equivalent of `configs.recommended` for consumers on
+  ESLint's legacy config system
 
 ### Changed
 - Removed npm-run-all dependency and updated scripts configuration
 - Added lint:fix script
 - Continuous integration action now using 'npm ci'
+
+### Breaking
+- `configs.recommended` is now an ESLint 9+ flat config object (`files`, `languageOptions.parser`, an
+  object-shaped `plugins` map) instead of the previous `.eslintrc`-shaped object. It was already
+  non-functional under flat config (the project's only supported ESLint major per `peerDependencies`), so
+  this fixes a real bug, but it is still a shape change for anyone spreading the old object directly -
+  see `configs.recommendedLegacy` above if you need the old shape.
 
 ### Dependencies
 - Bumped @html-eslint/eslint-plugin from 0.34.0 to 0.35.0

--- a/README.md
+++ b/README.md
@@ -40,6 +40,21 @@ export default [
 ];
 ```
 
+The preset registers this plugin under the `externalincludes` key, so if you want to override a rule's
+severity or options, reference it as `externalincludes/<rule>` (not the npm package name):
+
+```js
+export default [
+  externalincludes.configs.recommended,
+  {
+    files: ["**/*.html"],
+    rules: {
+      "externalincludes/enforce-no-external-url": ["error", { ignoreDomains: [".example.com"] }],
+    },
+  },
+];
+```
+
 ### Legacy `.eslintrc`
 
 Update your `.eslintrc` configuration file to add ESLint override for html files to specify the @html-eslint/parser and extend recommended rules if desired.
@@ -70,6 +85,12 @@ Then configure the rules you want to use under the rules section:
     }
 }
 ```
+
+Alternatively, `configs.recommendedLegacy` provides the same rule set in this `.eslintrc`-compatible shape
+(`{ plugins: [...], rules: {...} }`) if you'd rather spread it in than list the rules manually. Note it
+still only covers the `plugins`/`rules` portion - you still need the `overrides` block above (or equivalent)
+to wire up `@html-eslint/parser` for `*.html` files, since legacy `.eslintrc` config objects have no `files`
+scoping primitive of their own.
 
 If you are using the VS Code ESLint extension, update settings.json to include validation of html:
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,21 @@ While `@morgan-stanley/eslint-plugin-externalincludes` installs @html-eslint/esl
 
 ## Usage
 
+### Flat config (ESLint 9+)
+
+The simplest way to get started is the `recommended` config, which wires up `@html-eslint/parser`
+for `**/*.html` files and enables both rules:
+
+```js
+import externalincludes from "@morgan-stanley/eslint-plugin-externalincludes";
+
+export default [
+  externalincludes.configs.recommended,
+];
+```
+
+### Legacy `.eslintrc`
+
 Update your `.eslintrc` configuration file to add ESLint override for html files to specify the @html-eslint/parser and extend recommended rules if desired.
 Add `@html-eslint` and  `externalincludes` to the plugins section.
 You can omit the `eslint-plugin-` prefix:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,6 +4,7 @@ import { FlatCompat } from "@eslint/eslintrc";
 import path from "path";
 import { fileURLToPath } from "url";
 import licenseHeader from "eslint-plugin-license-header";
+import externalincludes from "./lib/index.js";
 
 // Get the directory name equivalent to __dirname in CommonJS
 const __filename = fileURLToPath(import.meta.url);
@@ -48,7 +49,12 @@ export default [
     ...eslintRecommended,
     ...eslintPluginRecommended,
     ...nRecommended,
-    
+
+    // Dogfood this plugin's own recommended preset against the HTML fixture below,
+    // so a regression in the flat-config wiring (parser, plugin key, file scoping)
+    // fails `npm run lint` instead of shipping silently.
+    externalincludes.configs.recommended,
+
     // Global configuration
     {
         files: ["**/*.js", "**/*.mjs", "**/*.cjs"],

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,15 +14,28 @@
 
 "use strict";
 
+/* eslint-disable n/no-unpublished-require -- peer deps, present at lint/consumption time */
+const htmlParser = require("@html-eslint/parser");
+const htmlEslint = require("@html-eslint/eslint-plugin");
+/* eslint-enable n/no-unpublished-require */
+
+const pkg = require("../package.json");
+
 /**
  * @fileoverview ESLint plugin for enforcing rules on external includes in HTML files
  * @author Morgan Stanley
  */
 
+const PLUGIN_KEY = "externalincludes";
+
 /**
  * @type {import('eslint').ESLint.Plugin}
  */
-module.exports = {
+const plugin = {
+    meta: {
+        name: pkg.name,
+        version: pkg.version,
+    },
     /**
      * Rule definitions for the plugin
      */
@@ -33,17 +46,27 @@ module.exports = {
     /**
      * Shareable configurations for the plugin
      */
-    configs:
-    {
-        /**
-         * Recommended configuration that enables the core rules
-         */
-        recommended: {
-            plugins:["externalincludes"],
-            rules: {
-                "externalincludes/enforce-no-external-url": "error",
-                "externalincludes/require-script-integrity": "warn"
-            }
-        }
+    configs: {}
+};
+
+/**
+ * Recommended configuration that enables the core rules. Shaped as an ESLint 9+
+ * flat config object: scoped to HTML files, with the HTML parser wired up so
+ * the rules' visitors actually run.
+ */
+plugin.configs.recommended = {
+    files: ["**/*.html"],
+    plugins: {
+        [PLUGIN_KEY]: plugin,
+        "@html-eslint": htmlEslint,
+    },
+    languageOptions: {
+        parser: htmlParser,
+    },
+    rules: {
+        [`${PLUGIN_KEY}/enforce-no-external-url`]: "error",
+        [`${PLUGIN_KEY}/require-script-integrity`]: "warn"
     }
-}
+};
+
+module.exports = plugin;

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,9 +14,11 @@
 
 "use strict";
 
+const { requirePeerDep } = require("./requirePeerDep");
+
 /* eslint-disable n/no-unpublished-require -- peer deps, present at lint/consumption time */
-const htmlParser = require("@html-eslint/parser");
-const htmlEslint = require("@html-eslint/eslint-plugin");
+const htmlParser = requirePeerDep("@html-eslint/parser");
+const htmlEslint = requirePeerDep("@html-eslint/eslint-plugin");
 /* eslint-enable n/no-unpublished-require */
 
 const pkg = require("../package.json");
@@ -63,6 +65,19 @@ plugin.configs.recommended = {
     languageOptions: {
         parser: htmlParser,
     },
+    rules: {
+        [`${PLUGIN_KEY}/enforce-no-external-url`]: "error",
+        [`${PLUGIN_KEY}/require-script-integrity`]: "warn"
+    }
+};
+
+// Legacy `.eslintrc`-shaped recommended configuration, matching the pre-flat-config shape of
+// `configs.recommended` prior to this version. Provided for consumers on ESLint's legacy config
+// system. As before, HTML files still need `@html-eslint/parser` wired up separately (e.g. via
+// an `overrides` entry) - this alone does not scope itself to HTML files the way the flat-config
+// `recommended` preset does, since legacy `.eslintrc` config objects have no `files` primitive.
+plugin.configs.recommendedLegacy = {
+    plugins: [PLUGIN_KEY],
     rules: {
         [`${PLUGIN_KEY}/enforce-no-external-url`]: "error",
         [`${PLUGIN_KEY}/require-script-integrity`]: "warn"

--- a/lib/requirePeerDep.js
+++ b/lib/requirePeerDep.js
@@ -1,0 +1,39 @@
+/*
+ * Morgan Stanley makes this available to you under the Apache License,
+ * Version 2.0 (the "License"). You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. Unless required by applicable law or agreed
+ * to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+"use strict";
+
+/**
+ * Requires a peer dependency, rethrowing a clearer, actionable error if it isn't
+ * installed rather than letting a bare `MODULE_NOT_FOUND` surface to the consumer.
+ *
+ * @param {string} name - The peer dependency's package name
+ * @returns {*} - The required module
+ */
+function requirePeerDep(name) {
+    try {
+        return require(name);
+    } catch (e) {
+        if (e && e.code === "MODULE_NOT_FOUND") {
+            throw new Error(
+                `@morgan-stanley/eslint-plugin-externalincludes requires the peer dependency "${name}" ` +
+                `to be installed. Run \`npm install ${name}\` (most package managers install peer ` +
+                "dependencies automatically, but this one didn't get installed) and try again."
+            );
+        }
+        throw e;
+    }
+}
+
+exports.requirePeerDep = requirePeerDep;

--- a/tests/fixtures/malformed.json
+++ b/tests/fixtures/malformed.json
@@ -1,0 +1,1 @@
+{ this is not valid JSON

--- a/tests/fixtures/recommended.html
+++ b/tests/fixtures/recommended.html
@@ -1,0 +1,25 @@
+<!--
+ Morgan Stanley makes this available to you under the Apache License,
+ Version 2.0 (the "License"). You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.
+
+ See the NOTICE file distributed with this work for additional information
+ regarding copyright ownership. Unless required by applicable law or agreed
+ to in writing, software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions
+ and limitations under the License.
+-->
+<!--
+ Dogfood fixture: linted by the project's own eslint.config.mjs using
+ plugin.configs.recommended, so a regression that breaks the flat-config
+ wiring (parser, plugin key, file scoping) fails `npm run lint`.
+-->
+<html>
+    <head>
+        <script src="./local-script.js"></script>
+        <link href="./local-styles.css" rel="stylesheet">
+    </head>
+    <body></body>
+</html>

--- a/tests/lib/index-test.js
+++ b/tests/lib/index-test.js
@@ -1,0 +1,51 @@
+/*
+ * Morgan Stanley makes this available to you under the Apache License,
+ * Version 2.0 (the "License"). You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. Unless required by applicable law or agreed
+ * to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+const assert = require("assert");
+const plugin = require("../../lib/index");
+const pkg = require("../../package.json");
+
+describe("plugin entry point", () => {
+    it("exposes meta matching package.json", () => {
+        assert.strictEqual(plugin.meta.name, pkg.name);
+        assert.strictEqual(plugin.meta.version, pkg.version);
+    });
+
+    it("exposes both rules", () => {
+        assert.ok(plugin.rules["enforce-no-external-url"]);
+        assert.ok(plugin.rules["require-script-integrity"]);
+    });
+
+    describe("configs.recommended (flat config)", () => {
+        const recommended = plugin.configs.recommended;
+
+        it("scopes itself to HTML files", () => {
+            assert.deepStrictEqual(recommended.files, ["**/*.html"]);
+        });
+
+        it("registers itself and @html-eslint under resolvable plugin keys", () => {
+            assert.strictEqual(recommended.plugins.externalincludes, plugin);
+            assert.ok(recommended.plugins["@html-eslint"]);
+        });
+
+        it("wires up the HTML parser", () => {
+            assert.ok(recommended.languageOptions.parser);
+        });
+
+        it("enables both rules with the expected severities", () => {
+            assert.strictEqual(recommended.rules["externalincludes/enforce-no-external-url"], "error");
+            assert.strictEqual(recommended.rules["externalincludes/require-script-integrity"], "warn");
+        });
+    });
+});

--- a/tests/lib/index-test.js
+++ b/tests/lib/index-test.js
@@ -48,4 +48,22 @@ describe("plugin entry point", () => {
             assert.strictEqual(recommended.rules["externalincludes/require-script-integrity"], "warn");
         });
     });
+
+    describe("configs.recommendedLegacy (.eslintrc-shaped)", () => {
+        const legacy = plugin.configs.recommendedLegacy;
+
+        it("registers the plugin under the legacy string-array shape", () => {
+            assert.deepStrictEqual(legacy.plugins, ["externalincludes"]);
+        });
+
+        it("enables both rules with the expected severities", () => {
+            assert.strictEqual(legacy.rules["externalincludes/enforce-no-external-url"], "error");
+            assert.strictEqual(legacy.rules["externalincludes/require-script-integrity"], "warn");
+        });
+
+        it("has no files/languageOptions - legacy .eslintrc has no such primitive", () => {
+            assert.strictEqual(legacy.files, undefined);
+            assert.strictEqual(legacy.languageOptions, undefined);
+        });
+    });
 });

--- a/tests/lib/requirePeerDep-test.js
+++ b/tests/lib/requirePeerDep-test.js
@@ -1,0 +1,49 @@
+/*
+ * Morgan Stanley makes this available to you under the Apache License,
+ * Version 2.0 (the "License"). You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. Unless required by applicable law or agreed
+ * to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+const assert = require("assert");
+const { requirePeerDep } = require("../../lib/requirePeerDep");
+
+describe("requirePeerDep", () => {
+    it("returns the module when it's installed", () => {
+        assert.strictEqual(requirePeerDep("assert"), require("assert"));
+    });
+
+    it("rethrows a clearer, actionable error when the module isn't found", () => {
+        assert.throws(
+            () => requirePeerDep("@morgan-stanley/this-package-does-not-exist-12345"),
+            (err) => {
+                assert.ok(err.message.includes("@morgan-stanley/this-package-does-not-exist-12345"));
+                assert.ok(err.message.includes("npm install"));
+                return true;
+            }
+        );
+    });
+
+    it("rethrows unrelated errors unchanged", () => {
+        // A malformed .json fixture fails with a SyntaxError (not MODULE_NOT_FOUND) when
+        // required, exercising requirePeerDep's plain `throw e;` fallback. Kept as .json
+        // (not .js) so mocha's recursive spec glob under tests/ doesn't try to run it.
+        // The exact V8 message wording for a JSON parse error varies by Node version, so
+        // assert on the error type/code rather than message text.
+        assert.throws(
+            () => requirePeerDep("../tests/fixtures/malformed.json"),
+            (err) => {
+                assert.ok(err instanceof SyntaxError);
+                assert.notStrictEqual(err.code, "MODULE_NOT_FOUND");
+                return true;
+            }
+        );
+    });
+});


### PR DESCRIPTION
Updates `configs.recommended` to the flat-config format used by ESLint 9+. The preset now scopes itself to `**/*.html`, wires up `@html-eslint/parser` through `languageOptions`, registers the plugin (and `@html-eslint`) as an object plugin map, and exposes `meta.name`/`meta.version` on the plugin export.

The project's own lint config now consumes the recommended preset against a fixture HTML file, and the README documents the flat-config usage alongside the existing legacy `.eslintrc` instructions.