### PR TITLE
chore: bump package version to 0.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@morgan-stanley/eslint-plugin-externalincludes",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@morgan-stanley/eslint-plugin-externalincludes",
-      "version": "0.0.2",
+      "version": "0.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/compat": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@morgan-stanley/eslint-plugin-externalincludes",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "Suite of @html-eslint ESLint rules for working with external references such as script src and link hrefs",
   "keywords": [
     "eslint",


### PR DESCRIPTION
## Summary
- bump package version to 0.1.0 in package.json
- align package-lock.json version fields with package.json

## Testing
- not run (metadata-only change)